### PR TITLE
Add associations and pass role colum from users to guests

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,7 @@
 class Project < ApplicationRecord
   belongs_to :user
 
-  has_many :week_ends
+  has_one :user
+  has_many :guests, dependent: :destroy
+  has_many :week_ends, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :projects
-
-  validates :first_name, presence: true
+  has_many :projects, through: :guests, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :projects, through: :guests, dependent: :destroy
+  has_many :projects, through: :guests
 end

--- a/db/migrate/20180529143250_remove_role_from_users.rb
+++ b/db/migrate/20180529143250_remove_role_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveRoleFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :role, :string
+  end
+end

--- a/db/migrate/20180529143326_add_role_to_guests.rb
+++ b/db/migrate/20180529143326_add_role_to_guests.rb
@@ -1,0 +1,5 @@
+class AddRoleToGuests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :guests, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_29_132444) do
+ActiveRecord::Schema.define(version: 2018_05_29_143326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2018_05_29_132444) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "budget"
+    t.string "role"
     t.index ["project_id"], name: "index_guests_on_project_id"
     t.index ["user_id"], name: "index_guests_on_user_id"
   end
@@ -51,7 +52,6 @@ ActiveRecord::Schema.define(version: 2018_05_29_132444) do
     t.datetime "updated_at", null: false
     t.string "first_name"
     t.string "last_name"
-    t.string "role"
     t.string "picture"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Added associations and passed 'role' in guests because we defined a role in the context of a project rather than of the app. 